### PR TITLE
Added handler to SIGTERM to exit with 0 in particle test

### DIFF
--- a/drake_cmake_installed/src/particles/uniformly_accelerated_particle.cc
+++ b/drake_cmake_installed/src/particles/uniformly_accelerated_particle.cc
@@ -2,6 +2,7 @@
 /// @brief  A simple 1DOF, constantly accelerated particle example.
 ///
 
+#include <csignal>
 #include <cstdlib>
 #include <limits>
 #include <memory>
@@ -18,6 +19,11 @@
 
 #include "particle.h"
 #include "utilities.h"
+
+void signalHandler( int signum ) {
+  std::cerr << "Interrupt signal (" << signum << ") received." << std::endl;
+  exit(0);
+}
 
 DEFINE_double(initial_position, 0.0,
               "Particle initial x position");
@@ -135,6 +141,7 @@ UniformlyAcceleratedParticle<T>::CreateContext(
 /// Main function for demo.
 ///
 int main(int argc, char* argv[]) {
+  std::signal(SIGTERM, signalHandler);
   gflags::SetUsageMessage("A very simple demonstration, "
                           "make sure drake-visualizer is running!");
   gflags::ParseCommandLineFlags(&argc, &argv, true);


### PR DESCRIPTION
Motivated by the need of running the particle example during a certain amount of time and make the test to a controlled shutdown and return 0.

In our test we used the `timeout` command:

 * Before these changes, the [run failed after the timeout command](https://build.osrfoundation.org/view/All/job/drake-ci-pr_any-xenial-amd64/24/console)
 * Using a fork with these changes, the [run succeeded](https://build.osrfoundation.org/view/All/job/drake-ci-pr_any-xenial-amd64/30/console)

It can be manually tested by:
```
timeout --preserve-status 5 ./uniformly_accelerated_particle_demo
echo $?
```