### PR TITLE
Add Developer Testing variant to documentation.

### DIFF
--- a/drake_cmake_installed/README.md
+++ b/drake_cmake_installed/README.md
@@ -6,7 +6,7 @@ This uses the CMake `find_package(drake)` mechanism to find an installed instanc
 
 These instructions are only supported for Ubuntu 16.04 (Xenial).
 
-```
+```shell
 ###############################################################
 # Install Prerequisites
 ###############################################################

--- a/drake_cmake_installed/README.md
+++ b/drake_cmake_installed/README.md
@@ -45,9 +45,9 @@ sudo tar -xvzf drake-latest-xenial.tar.gz -C /opt
 # Build Everything
 ###############################################################
 git clone https://github.com/RobotLocomotion/drake-shambhala.git
-cd drake-shambhala/drake_cmake_installed
-mkdir build && cd build
-cmake -Ddrake_DIR=/opt/drake/lib/cmake/drake ..
+cd drake-shambhala
+mkdir drake_cmake_installed-build && cd drake_cmake_installed-build
+cmake -Ddrake_DIR=/opt/drake/lib/cmake/drake ../drake_cmake_installed
 make
 
 ###############################################################
@@ -72,3 +72,35 @@ Drake specific Examples:
 Compatibility Examples:
 
 * [PCL](src/pcl/README.md)
+
+# Developer Testing
+
+If you are a Drake Developer making build or API changes that may affect the
+downstream interface, please test this locally on your system.
+
+These build instructions are adapted from those above, but will use an existing
+source tree of Drake (but *not* installing it to `/opt/drake`),
+build this project, and then run all available tests:
+
+```shell
+# Build development version of Drake, ensuring no old artifacts are present.
+cd drake  # Where you are developing.
+rm -rf ../drake-build && mkdir ../drake-build && cd ../drake-build
+cmake ../drake  # Configure Gurobi, Mosek, etc, if needed.
+# Build locally.
+make
+# Record the build's install directory.
+drake_install=${PWD}/install
+
+# Build Drake Shambhala using development version of Drake.
+cd ..
+# Clone `drake-shambhala` if you have not already.
+git clone https://github.com/RobotLocomotion/drake-shambhala
+cd drake-shambhala
+# Follow "Install Prerequisites" in the instructions linked above if you
+# have not already.
+mkdir drake_cmake_installed-build && cd drake_cmake_installed-build
+cmake -Ddrake_DIR=${drake_install}/lib/cmake/drake ../drake_cmake_installed
+make
+ctest
+```


### PR DESCRIPTION
Relates https://github.com/RobotLocomotion/drake/pull/7737

As a developer, I would prefer to have specific instructions with as few options as possible, without the need to find/replace for `/opt/drake`, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-shambhala/80)
<!-- Reviewable:end -->
