### PR TITLE
find_resource: Don't use GTest if it's not easily enabled.

### DIFF
--- a/drake_cmake_installed/src/find_resource/CMakeLists.txt
+++ b/drake_cmake_installed/src/find_resource/CMakeLists.txt
@@ -30,15 +30,9 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-find_package(GTest)
-
-if(GTEST_FOUND)
-  configure_file(find_resource.cc.in ${CMAKE_CURRENT_BINARY_DIR}/find_resource.cc)
-  add_executable(test_find_resource ${CMAKE_CURRENT_BINARY_DIR}/find_resource.cc)
-  target_link_libraries(test_find_resource GTest::GTest GTest::Main drake::drake)
-
-  add_test(NAME test_find_resource COMMAND test_find_resource)
-endif()
+add_executable(test_find_resource find_resource.cc)
+target_link_libraries(test_find_resource drake::drake)
+add_test(NAME test_find_resource COMMAND test_find_resource)
 
 add_test(
     NAME test_find_resource_py

--- a/drake_cmake_installed/src/find_resource/find_resource.cc
+++ b/drake_cmake_installed/src/find_resource/find_resource.cc
@@ -33,33 +33,31 @@
 /// @brief  A simple find_resource test for locating installed drake resources.
 ///
 
-#include <cstdlib>
-
-#include <gtest/gtest.h>
+#include <iostream>
+#include <stdexcept>
 
 #include <drake/common/find_resource.h>
 
 namespace shambhala {
-namespace find_resource {
 namespace {
 
-GTEST_TEST(FindResource, Available)
-{
-  drake::AddResourceSearchPath("@drake_DIR@/../../../share/drake");
-  auto result = drake::FindResourceOrThrow("drake/manipulation/models/iiwa_description/urdf/iiwa14_primitive_collision.urdf");
-  // it will throw if it does not find the resource correctly
-  SUCCEED();
+int main() {
+  drake::FindResourceOrThrow(
+      "drake/manipulation/models/iiwa_description/urdf/"
+      "iiwa14_primitive_collision.urdf");
+
+  try {
+    drake::FindResourceOrThrow("nobody_home.urdf");
+    std::cerr << "Should have thrown" << std::endl;
+    return 1;
+  } catch (const std::runtime_error&) {}
+
+  return 0;
 }
 
-    /// Makes sure that find_resource throws when given a unavailable resource.
-GTEST_TEST(FindResource, NotAvailable)
-{
-  ASSERT_THROW(
-    {drake::FindResourceOrThrow("nobody_home.urdf");},
-    std::runtime_error
-  );
-}
-
-}
-}  // namespace find_resource
+}  // namespace
 }  // namespace shambhala
+
+int main() {
+  return shambhala::main();
+}


### PR DESCRIPTION
Closes #86.

This is a minor change to ensure this test is run, given that `find_package(GTest)` is not functional out-of-the-box.

I can live with/without it, but would like to ensure this test is run.

\cc @jamiesnape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-shambhala/87)
<!-- Reviewable:end -->
