### PR TITLE
bazel: Expose scalar types in custom pydrake bindings

### DIFF
--- a/drake_bazel_external/apps/BUILD.bazel
+++ b/drake_bazel_external/apps/BUILD.bazel
@@ -103,7 +103,11 @@ pybind_py_library(
     name = "simple_adder_py",
     cc_so_name = "simple_adder",
     cc_srcs = ["simple_adder_py.cc"],
-    cc_deps = [":simple_adder"],
+    cc_deps = [
+        ":simple_adder",
+        "@drake//bindings/pydrake/systems:systems_pybind",
+        "@drake//bindings/pydrake/util:cpp_template_pybind",
+    ],
     py_deps = ["@drake//bindings/pydrake"],
     py_imports = ["."],
 )

--- a/drake_bazel_external/apps/simple_adder_py.cc
+++ b/drake_bazel_external/apps/simple_adder_py.cc
@@ -37,10 +37,16 @@
 
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/systems/systems_pybind.h"
+#include "drake/bindings/pydrake/util/cpp_template_pybind.h"
+
 #include "simple_adder.h"
 
 namespace py = pybind11;
 
+using drake::pydrake::DefineTemplateClassWithDefault;
+using drake::pydrake::GetPyParam;
+using drake::pydrake::pysystems::CommonScalarPack;
 using drake::systems::LeafSystem;
 
 namespace shambhala {
@@ -51,8 +57,14 @@ PYBIND11_MODULE(simple_adder, m) {
 
   py::module::import("pydrake.systems.framework");
 
-  py::class_<SimpleAdder<double>, LeafSystem<double>>(m, "SimpleAdder")
+  auto bind_common_scalar_types = [m](auto dummy) {
+    using T = decltype(dummy);
+
+    DefineTemplateClassWithDefault<SimpleAdder<T>, LeafSystem<T>>(
+        m, "SimpleAdder", GetPyParam<T>())
       .def(py::init<double>(), py::arg("add"));
+  };
+  type_visit(bind_common_scalar_types, CommonScalarPack{});
 }
 
 }  // namespace

--- a/drake_bazel_external/apps/simple_adder_py_test.py
+++ b/drake_bazel_external/apps/simple_adder_py_test.py
@@ -33,12 +33,15 @@ Provides an example of using pybind11-bound Drake C++ system with pydrake.
 
 from __future__ import print_function
 
-from simple_adder import SimpleAdder
+from simple_adder import SimpleAdder, SimpleAdder_
 
 import numpy as np
 
+from pydrake.autodiffutils import AutoDiffXd
+from pydrake.symbolic import Expression
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (
+    BasicVector_,
     DiagramBuilder,
 )
 from pydrake.systems.primitives import (
@@ -48,6 +51,7 @@ from pydrake.systems.primitives import (
 
 
 def main():
+    # Simulate with doubles.
     builder = DiagramBuilder()
     source = builder.AddSystem(ConstantVectorSource([10.]))
     adder = builder.AddSystem(SimpleAdder(100.))
@@ -62,6 +66,20 @@ def main():
     x = logger.data()
     print("Output values: {}".format(x))
     assert np.allclose(x, 110.)
+
+    # Compute outputs with AutoDiff and Symbolic.
+    for T in (AutoDiffXd, Expression):
+        adder_T = SimpleAdder_[T](100.)
+        context = adder_T.CreateDefaultContext()
+        context.FixInputPort(0, BasicVector_[T]([10.]))
+        output = adder_T.AllocateOutput(context)
+        adder_T.CalcOutput(context, output)
+        # N.B. At present, you cannot get a reference to existing AutoDiffXd
+        # or Expression numpy arrays, so we will explictly copy the vector:
+        # https://github.com/RobotLocomotion/drake/issues/8116
+        value, = output.get_vector_data(0).CopyToVector()
+        assert isinstance(value, T)
+        print("Output from {}: {}".format(type(adder_T), repr(value)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Example for RobotLocomotion/drake#9009
- [x] Requires RobotLocomotion/drake#9010

\cc @mposa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-shambhala/109)
<!-- Reviewable:end -->
