### PR TITLE
Hotfix for rename of input_port{_descriptor => }.h

### DIFF
--- a/drake_cmake_installed/src/particles/particle_test.cc
+++ b/drake_cmake_installed/src/particles/particle_test.cc
@@ -35,7 +35,7 @@
 
 #include <gtest/gtest.h>
 
-#include <drake/systems/framework/input_port_descriptor.h>
+#include <drake/systems/framework/input_port.h>
 #include <drake/systems/framework/output_port_value.h>
 #include <drake/systems/framework/system.h>
 #include <drake/systems/framework/vector_base.h>
@@ -97,7 +97,7 @@ TYPED_TEST_P(ParticleTest, OutputTest) {
 /// consistent with its state and input (velocity and acceleration).
 TYPED_TEST_P(ParticleTest, DerivativesTest) {
   // Set input.
-  const drake::systems::InputPortDescriptor<TypeParam>& input_descriptor =
+  const drake::systems::InputPort<TypeParam>& input_descriptor =
       this->dut_->get_input_port(0);
   auto input = std::make_unique<drake::systems::BasicVector<TypeParam>>(
       input_descriptor.size());

--- a/drake_cmake_installed/src/particles/utilities_test.cc
+++ b/drake_cmake_installed/src/particles/utilities_test.cc
@@ -38,7 +38,7 @@
 
 #include <drake/systems/framework/basic_vector.h>
 #include <drake/systems/framework/context.h>
-#include <drake/systems/framework/input_port_descriptor.h>
+#include <drake/systems/framework/input_port.h>
 #include <drake/systems/framework/output_port_value.h>
 #include <drake/systems/framework/system.h>
 
@@ -81,7 +81,7 @@ TYPED_TEST_CASE_P(SingleDOFEulerJointTest);
 /// output is the right mapping of its inputs.
 TYPED_TEST_P(SingleDOFEulerJointTest, OutputTest) {
   // Set input.
-  const drake::systems::InputPortDescriptor<TypeParam>& input_descriptor =
+  const drake::systems::InputPort<TypeParam>& input_descriptor =
       this->dut_->get_input_port(0);
   auto input = std::make_unique<drake::systems::BasicVector<TypeParam>>(
       input_descriptor.size());


### PR DESCRIPTION
\cc @sherm1 